### PR TITLE
remove deprecated role variable

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,4 +15,3 @@ galaxy_info:
     - webserver
     - wpplication
 dependencies: []
-version: 2.0.0


### PR DESCRIPTION
Hi, 

The version variable no longer works.  Here is a pull request where it is removed.  Thank you for the role.  
